### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -4,6 +4,10 @@ on:
     release:
         types: [released]
 
+permissions:
+    contents: read
+    packages: write
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/defnone/quickfeeds/security/code-scanning/25](https://github.com/defnone/quickfeeds/security/code-scanning/25)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves reading repository contents, interacting with releases, and pushing Docker images, the following permissions are appropriate:
- `contents: read` for accessing repository files.
- `packages: write` for pushing Docker images to the GitHub Container Registry.
- `pull-requests: write` if the workflow interacts with pull requests (not explicitly shown in the provided code).

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit permissions to that specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
